### PR TITLE
Pick output folder

### DIFF
--- a/Support Files/en.lproj/Localizable.strings
+++ b/Support Files/en.lproj/Localizable.strings
@@ -18,6 +18,7 @@
 "nef_extension" = "Xcode Source Editor";
 
 // MARK: - Preferences
+"output_folder_title" = "Output Folder";
 "check_option_title" = "Show";
 "preferences_title" = "Carbon";
 "preferences_option_font" = "Font type";

--- a/Support Files/es.lproj/Localizable.strings
+++ b/Support Files/es.lproj/Localizable.strings
@@ -18,6 +18,7 @@
 "nef_extension" = "Editor de código de Xcode";
 
 // MARK: - Preferences
+"output_folder_title" = "Directorio de salida";
 "check_option_title" = "Mostrar";
 "preferences_title" = "Carbon";
 "preferences_option_font" = "Tipo de fuente";

--- a/nef-plugin.xcodeproj/project.pbxproj
+++ b/nef-plugin.xcodeproj/project.pbxproj
@@ -620,11 +620,11 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "nef/Support Files/nef.entitlements";
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 47;
-				DEVELOPMENT_TEAM = P548S5LU96;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "nef/Support Files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -634,7 +634,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.fortysevendeg.nef;
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)App";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = nef;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
@@ -645,11 +645,11 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "nef/Support Files/nef.entitlements";
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 47;
-				DEVELOPMENT_TEAM = P548S5LU96;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "nef/Support Files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -659,7 +659,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.fortysevendeg.nef;
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)App";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = nef;
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
@@ -668,11 +668,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "nef-plugin/Support Files/nef_plugin.entitlements";
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 47;
-				DEVELOPMENT_TEAM = P548S5LU96;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "nef-plugin/Support Files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -683,7 +683,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.fortysevendeg.nef-plugin";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "nef-plugin";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
@@ -692,11 +692,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "nef-plugin/Support Files/nef_plugin.entitlements";
-				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 47;
-				DEVELOPMENT_TEAM = P548S5LU96;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = "nef-plugin/Support Files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -707,7 +707,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.fortysevendeg.nef-plugin";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "nef-plugin";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;

--- a/nef-plugin.xcodeproj/project.pbxproj
+++ b/nef-plugin.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		8B4D1E1522D7A37E004432CF /* PickerOptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4D1E1422D7A37E004432CF /* PickerOptionView.swift */; };
 		8B4D1E1722D88A5E004432CF /* OptionItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4D1E1622D88A5E004432CF /* OptionItem.swift */; };
 		8B50B4A1234C8FBC00C2429D /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B50B4A0234C8FBC00C2429D /* Reachability.swift */; };
+		8B7E0622235493F7003ED8E2 /* NSWindow+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7E0621235493F7003ED8E2 /* NSWindow+Extension.swift */; };
 		8B9F3CEF22EF2D48001EE2DF /* CarbonWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B9F3CEE22EF2D48001EE2DF /* CarbonWebView.swift */; };
 		8B9F3CF122F036BD001EE2DF /* CarbonViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B9F3CF022F036BD001EE2DF /* CarbonViewer.swift */; };
 		8B9F3CF322F036E3001EE2DF /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B9F3CF222F036E3001EE2DF /* LoadingView.swift */; };
@@ -41,6 +42,7 @@
 		8BF68FB122DE0ED4009E57A9 /* PreferencesModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF68FB022DE0ED4009E57A9 /* PreferencesModel.swift */; };
 		8BF68FB322DE2154009E57A9 /* PreferencesViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF68FB222DE2154009E57A9 /* PreferencesViewModel.swift */; };
 		8BF68FB522DE2403009E57A9 /* CarbonStyle+Model.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF68FB422DE2403009E57A9 /* CarbonStyle+Model.swift */; };
+		8BF9220623546D8D00C58AA0 /* OpenPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF9220523546D8D00C58AA0 /* OpenPanel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -80,6 +82,7 @@
 		8B4D1E1422D7A37E004432CF /* PickerOptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickerOptionView.swift; sourceTree = "<group>"; };
 		8B4D1E1622D88A5E004432CF /* OptionItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionItem.swift; sourceTree = "<group>"; };
 		8B50B4A0234C8FBC00C2429D /* Reachability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reachability.swift; sourceTree = "<group>"; };
+		8B7E0621235493F7003ED8E2 /* NSWindow+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSWindow+Extension.swift"; sourceTree = "<group>"; };
 		8B9F3CEE22EF2D48001EE2DF /* CarbonWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarbonWebView.swift; sourceTree = "<group>"; };
 		8B9F3CF022F036BD001EE2DF /* CarbonViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarbonViewer.swift; sourceTree = "<group>"; };
 		8B9F3CF222F036E3001EE2DF /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
@@ -108,6 +111,7 @@
 		8BF68FB022DE0ED4009E57A9 /* PreferencesModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreferencesModel.swift; sourceTree = "<group>"; };
 		8BF68FB222DE2154009E57A9 /* PreferencesViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreferencesViewModel.swift; sourceTree = "<group>"; };
 		8BF68FB422DE2403009E57A9 /* CarbonStyle+Model.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CarbonStyle+Model.swift"; sourceTree = "<group>"; };
+		8BF9220523546D8D00C58AA0 /* OpenPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenPanel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -151,6 +155,7 @@
 			isa = PBXGroup;
 			children = (
 				8B3B21A922F8329900E92BC9 /* Browser.swift */,
+				8BF9220523546D8D00C58AA0 /* OpenPanel.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -162,6 +167,7 @@
 				8BF68FB422DE2403009E57A9 /* CarbonStyle+Model.swift */,
 				8BAAB73C22D4DB2A00FD3636 /* Date+Extension.swift */,
 				8B9F3CF422F03704001EE2DF /* NSView+Layout.swift */,
+				8B7E0621235493F7003ED8E2 /* NSWindow+Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -414,6 +420,7 @@
 			files = (
 				8B2CE74622D89C8900571F24 /* CheckOptionView.swift in Sources */,
 				8B9F3CF522F03704001EE2DF /* NSView+Layout.swift in Sources */,
+				8B7E0622235493F7003ED8E2 /* NSWindow+Extension.swift in Sources */,
 				8BF68FB322DE2154009E57A9 /* PreferencesViewModel.swift in Sources */,
 				8B4D1E1522D7A37E004432CF /* PickerOptionView.swift in Sources */,
 				8B3B21AC22F8644000E92BC9 /* FixedToggle.swift in Sources */,
@@ -423,6 +430,7 @@
 				8BF68FA322DDE268009E57A9 /* ActionViewModel.swift in Sources */,
 				8B2CE74822D8A35400571F24 /* ColorOptionView.swift in Sources */,
 				8BF68FA122DDD8BD009E57A9 /* Assembler.swift in Sources */,
+				8BF9220623546D8D00C58AA0 /* OpenPanel.swift in Sources */,
 				8BB2892E22CB6EFB006E4CCB /* AppDelegate.swift in Sources */,
 				8B4D1E1722D88A5E004432CF /* OptionItem.swift in Sources */,
 				8BF68FB522DE2403009E57A9 /* CarbonStyle+Model.swift in Sources */,
@@ -608,11 +616,11 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "nef/Support Files/nef.entitlements";
-				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_IDENTITY = "Mac Developer";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 47;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = P548S5LU96;
 				INFOPLIST_FILE = "nef/Support Files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -622,7 +630,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.fortysevendeg.nef;
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)App";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = nef;
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
@@ -633,11 +641,11 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = "nef/Support Files/nef.entitlements";
-				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_IDENTITY = "Mac Developer";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 47;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = P548S5LU96;
 				INFOPLIST_FILE = "nef/Support Files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -647,7 +655,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.fortysevendeg.nef;
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME:c99extidentifier)App";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = nef;
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
@@ -656,11 +664,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "nef-plugin/Support Files/nef_plugin.entitlements";
-				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_IDENTITY = "Mac Developer";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 47;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = P548S5LU96;
 				INFOPLIST_FILE = "nef-plugin/Support Files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -671,7 +679,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.fortysevendeg.nef-plugin";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "nef-plugin";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
@@ -680,11 +688,11 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CODE_SIGN_ENTITLEMENTS = "nef-plugin/Support Files/nef_plugin.entitlements";
-				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_IDENTITY = "Mac Developer";
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 47;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = P548S5LU96;
 				INFOPLIST_FILE = "nef-plugin/Support Files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -695,7 +703,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "com.fortysevendeg.nef-plugin";
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "nef-plugin";
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;

--- a/nef-plugin.xcodeproj/project.pbxproj
+++ b/nef-plugin.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		8B4D1E1722D88A5E004432CF /* OptionItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4D1E1622D88A5E004432CF /* OptionItem.swift */; };
 		8B50B4A1234C8FBC00C2429D /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B50B4A0234C8FBC00C2429D /* Reachability.swift */; };
 		8B7E0622235493F7003ED8E2 /* NSWindow+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7E0621235493F7003ED8E2 /* NSWindow+Extension.swift */; };
+		8B7E0624235498CA003ED8E2 /* OutputFolderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7E0623235498CA003ED8E2 /* OutputFolderView.swift */; };
 		8B9F3CEF22EF2D48001EE2DF /* CarbonWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B9F3CEE22EF2D48001EE2DF /* CarbonWebView.swift */; };
 		8B9F3CF122F036BD001EE2DF /* CarbonViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B9F3CF022F036BD001EE2DF /* CarbonViewer.swift */; };
 		8B9F3CF322F036E3001EE2DF /* LoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B9F3CF222F036E3001EE2DF /* LoadingView.swift */; };
@@ -83,6 +84,7 @@
 		8B4D1E1622D88A5E004432CF /* OptionItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionItem.swift; sourceTree = "<group>"; };
 		8B50B4A0234C8FBC00C2429D /* Reachability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reachability.swift; sourceTree = "<group>"; };
 		8B7E0621235493F7003ED8E2 /* NSWindow+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSWindow+Extension.swift"; sourceTree = "<group>"; };
+		8B7E0623235498CA003ED8E2 /* OutputFolderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutputFolderView.swift; sourceTree = "<group>"; };
 		8B9F3CEE22EF2D48001EE2DF /* CarbonWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarbonWebView.swift; sourceTree = "<group>"; };
 		8B9F3CF022F036BD001EE2DF /* CarbonViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarbonViewer.swift; sourceTree = "<group>"; };
 		8B9F3CF222F036E3001EE2DF /* LoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoadingView.swift; sourceTree = "<group>"; };
@@ -191,6 +193,7 @@
 				8B4D1E1422D7A37E004432CF /* PickerOptionView.swift */,
 				8B9F3CF022F036BD001EE2DF /* CarbonViewer.swift */,
 				8B9F3CEE22EF2D48001EE2DF /* CarbonWebView.swift */,
+				8B7E0623235498CA003ED8E2 /* OutputFolderView.swift */,
 				8B0389AE22F04F6C000741A5 /* Models */,
 			);
 			path = Views;
@@ -432,6 +435,7 @@
 				8BF68FA122DDD8BD009E57A9 /* Assembler.swift in Sources */,
 				8BF9220623546D8D00C58AA0 /* OpenPanel.swift in Sources */,
 				8BB2892E22CB6EFB006E4CCB /* AppDelegate.swift in Sources */,
+				8B7E0624235498CA003ED8E2 /* OutputFolderView.swift in Sources */,
 				8B4D1E1722D88A5E004432CF /* OptionItem.swift in Sources */,
 				8BF68FB522DE2403009E57A9 /* CarbonStyle+Model.swift in Sources */,
 				8BAAB73D22D4DB2A00FD3636 /* Date+Extension.swift in Sources */,

--- a/nef/AppDelegate.swift
+++ b/nef/AppDelegate.swift
@@ -61,7 +61,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     }
     
     private func preferencesDidFinishLaunching() {
-        window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 800, height: 740),
+        window = NSWindow(contentRect: NSRect(x: 0, y: 0, width: 800, height: 760),
                           styleMask: [.titled, .closable, .miniaturizable],
                           backing: .buffered, defer: false)
         
@@ -82,7 +82,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     
     // MARK: private methods
     private func carbonWindow(code: String) -> NSWindow? {
-        guard let writableFolder = assembler.resolveOpenPanel().writableFolder() else { return nil }
+        guard let writableFolder = assembler.resolveOpenPanel().writableFolder(create: true) else { return nil }
         
         let filename = "nef \(Date.now.human)"
         let outputPath = writableFolder.appendingPathComponent(filename).path

--- a/nef/AppDelegate.swift
+++ b/nef/AppDelegate.swift
@@ -76,8 +76,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         guard !code.isEmpty else { terminate(); return }
         guard let _ = carbonWindow(code: code) else { terminate(); return }
         
-        self.window = NSWindow.empty
-        self.window.makeKeyAndOrderFront(nil)
+        window = NSWindow.empty
+        window.makeKeyAndOrderFront(nil)
     }
     
     // MARK: private methods

--- a/nef/AppDelegate.swift
+++ b/nef/AppDelegate.swift
@@ -1,7 +1,6 @@
 //  Copyright © 2019 The nef Authors.
 
 import SwiftUI
-import NefCarbon
 
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {

--- a/nef/AppDelegate.swift
+++ b/nef/AppDelegate.swift
@@ -1,6 +1,7 @@
 //  Copyright © 2019 The nef Authors.
 
 import SwiftUI
+import NefCarbon
 
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
@@ -73,18 +74,18 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     
     private func carbonDidFinishLaunching(code: String) {
         guard !code.isEmpty else { terminate(); return }
-        guard let carbonWindow = carbonWindow(code: code) else { terminate(); return }
+        guard let _ = carbonWindow(code: code) else { terminate(); return }
         
-        window = carbonWindow
-        window.makeKey()
+        self.window = NSWindow.empty
+        self.window.makeKeyAndOrderFront(nil)
     }
     
     // MARK: private methods
     private func carbonWindow(code: String) -> NSWindow? {
-        guard let downloadsFolder = try? FileManager.default.url(for: .downloadsDirectory, in: .userDomainMask, appropriateFor: nil, create: false) else { return nil }
+        guard let writableFolder = assembler.resolveOpenPanel().writableFolder() else { return nil }
         
         let filename = "nef \(Date.now.human)"
-        let outputPath = downloadsFolder.appendingPathComponent(filename).path
+        let outputPath = writableFolder.appendingPathComponent(filename).path
         
         return assembler.resolveCarbonWindow(code: code, outputPath: outputPath) { status in
             if status {
@@ -92,24 +93,17 @@ class AppDelegate: NSObject, NSApplicationDelegate {
                 self.showFile(file)
             }
             
-            self.beep(success: status)
             self.terminate()
         }
     }
-    
+
     private func showFile(_ file: URL) {
         NSWorkspace.shared.activateFileViewerSelecting([file])
     }
     
-    private func beep(success: Bool) {
-        NSSound(named: success ? "Tink" : "Bottle")?.play()
-    }
-    
     private func terminate() {
-        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(250)) {
-            DispatchQueue.main.async {
-                NSApplication.shared.terminate(nil)
-            }
+        DispatchQueue.main.async {
+            NSApplication.shared.terminate(nil)
         }
     }
     

--- a/nef/Assembler.swift
+++ b/nef/Assembler.swift
@@ -25,14 +25,6 @@ class Assembler {
                    success: { completion(true) }, failure: { _ in completion(false) })
     }
     
-    func resolveCarbonWindow(parent: NSView, code: String, outputPath: String, completion: @escaping (_ status: Bool) -> Void) {
-        nef.carbon(parentView: parent,
-                   code: code,
-                   style: preferencesDataSource.state.style,
-                   outputPath: outputPath,
-                   success: { completion(true) }, failure: { _ in completion(false) })
-    }
-    
     // MARK: - utils
     func resolveOpenPanel() -> OpenPanel { OpenPanel() }
     

--- a/nef/Assembler.swift
+++ b/nef/Assembler.swift
@@ -25,6 +25,17 @@ class Assembler {
                    success: { completion(true) }, failure: { _ in completion(false) })
     }
     
+    func resolveCarbonWindow(parent: NSView, code: String, outputPath: String, completion: @escaping (_ status: Bool) -> Void) {
+        nef.carbon(parentView: parent,
+                   code: code,
+                   style: preferencesDataSource.state.style,
+                   outputPath: outputPath,
+                   success: { completion(true) }, failure: { _ in completion(false) })
+    }
+    
+    // MARK: - utils
+    func resolveOpenPanel() -> OpenPanel { OpenPanel() }
+    
     // MARK: - private methods
     private func resolvePreferencesViewModel() -> PreferencesViewModel {
         return PreferencesViewModel(preferences: preferencesDataSource,

--- a/nef/Extensions/NSWindow+Extension.swift
+++ b/nef/Extensions/NSWindow+Extension.swift
@@ -1,0 +1,12 @@
+//  Copyright © 2019 The nef Authors.
+
+import AppKit
+
+extension NSWindow {
+    
+    static var empty: NSWindow {
+        let window = NSWindow()
+        window.setFrame(.zero, display: false)
+        return window
+    }
+}

--- a/nef/Preferences/PreferencesView.swift
+++ b/nef/Preferences/PreferencesView.swift
@@ -28,6 +28,8 @@ struct PreferencesView: View {
              .border(NefColor.border)
             
             // Preferences options
+            OutputFolderView().offset(x: -12, y: 12)
+            
             VStack {
                 CheckOptionView(text: i18n.Description.showLines, nested: false, selection: $viewModel.showLines)
                 CheckOptionView(text: i18n.Description.showWatermark, nested: true, selection: $viewModel.showWatermark)

--- a/nef/Preferences/Views/OutputFolderView.swift
+++ b/nef/Preferences/Views/OutputFolderView.swift
@@ -1,0 +1,54 @@
+//  Copyright © 2019 The nef Authors.
+
+import SwiftUI
+
+struct OutputFolderView: View {
+    
+    private let openPanel = OpenPanel()
+    @State var outputPath: String = ""
+    
+    var body: some View {
+        HStack(alignment: .top) {
+            Text("\(i18n.title):")
+                .frame(width: PreferencesView.Layout.leftPanel, alignment: .trailing)
+            
+            HStack(alignment: .bottom) {
+                Text(outputPath)
+                    .font(.system(.caption)).fontWeight(.light)
+                    .lineLimit(1)
+                    .ligthGray
+                
+                Text("􀉓")
+                    .font(.system(.caption)).fontWeight(.light)
+                    .regularGray
+            }.frame(width: PreferencesView.Layout.rightPanel+Constant.rightPanelExtraWidth, alignment: .leading)
+             .onTapGesture { self.selectWritableFolder() }
+            
+        }.offset(x: Constant.rightPanelExtraWidth/2)
+         .onAppear(perform: onAppear)
+    }
+    
+    private func onAppear() {
+        outputPath = openPanel.writableFolder(create: false)?.path ?? ""
+    }
+    
+    private func selectWritableFolder() {
+        guard let url = openPanel.selectWritableFolder() else { return }
+        outputPath = url.path
+    }
+    
+    // MARK: - Constants
+    enum i18n {
+        static let title = NSLocalizedString("output_folder_title", comment: "")
+    }
+    
+    enum Constant {
+        static let rightPanelExtraWidth: CGFloat = 180
+    }
+}
+
+
+fileprivate extension View {
+    var ligthGray: some View { self.foregroundColor(.init(white: 0.7)) }
+    var regularGray: some View { self.foregroundColor(.init(white: 0.6)) }
+}

--- a/nef/Support Files/nef.entitlements
+++ b/nef/Support Files/nef.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.security.app-sandbox</key>
 	<true/>
-	<key>com.apple.security.files.downloads.read-write</key>
+	<key>com.apple.security.files.user-selected.read-write</key>
 	<true/>
 	<key>com.apple.security.network.client</key>
 	<true/>

--- a/nef/Utils/OpenPanel.swift
+++ b/nef/Utils/OpenPanel.swift
@@ -15,16 +15,15 @@ class OpenPanel {
         dialog.allowsMultipleSelection = false
     }
     
-    func writableFolder() -> URL? {
+    func writableFolder(create: Bool) -> URL? {
         guard let url = retrieveBookmark(), existFolder(at: url) else {
-            return selectWritableFolder()
+            return create ? selectWritableFolder() : nil
         }
         
         return url
     }
     
-    // MARK: private methods
-    private func selectWritableFolder() -> URL? {
+    func selectWritableFolder() -> URL? {
         guard dialog.runModal() == .OK,
               let selection = dialog.url else { return nil }
         
@@ -34,6 +33,7 @@ class OpenPanel {
         return selection
     }
     
+    // MARK: private methods
     private func persistBookmark(url: URL) {
         let data = try? url.bookmarkData(options: .withSecurityScope, includingResourceValuesForKeys: nil, relativeTo: nil)
         storage.setValue(data, forKey: Key.bookmark)

--- a/nef/Utils/OpenPanel.swift
+++ b/nef/Utils/OpenPanel.swift
@@ -1,0 +1,62 @@
+//  Copyright © 2019 The nef Authors.
+
+import AppKit
+
+class OpenPanel {
+    private let dialog: NSOpenPanel
+    private let storage: UserDefaults
+    
+    init() {
+        self.storage = UserDefaults.standard
+        self.dialog = NSOpenPanel()
+        
+        dialog.canChooseFiles = false
+        dialog.canChooseDirectories = true
+        dialog.allowsMultipleSelection = false
+    }
+    
+    func writableFolder() -> URL? {
+        guard let url = retrieveBookmark(), existFolder(at: url) else {
+            return selectWritableFolder()
+        }
+        
+        return url
+    }
+    
+    // MARK: private methods
+    private func selectWritableFolder() -> URL? {
+        guard dialog.runModal() == .OK,
+              let selection = dialog.url else { return nil }
+        
+        closeAccessingBookmark()
+        persistBookmark(url: selection)
+        
+        return selection
+    }
+    
+    private func persistBookmark(url: URL) {
+        let data = try? url.bookmarkData(options: .withSecurityScope, includingResourceValuesForKeys: nil, relativeTo: nil)
+        storage.setValue(data, forKey: Key.bookmark)
+    }
+    
+    private func retrieveBookmark() -> URL? {
+        guard let data = storage.data(forKey: Key.bookmark) else { return nil }
+        var bookmarkDataIsStale: Bool = true
+        let url = try? URL(resolvingBookmarkData: data, options: .withSecurityScope, relativeTo: nil, bookmarkDataIsStale: &bookmarkDataIsStale)
+        _ = url?.startAccessingSecurityScopedResource()
+        return url
+    }
+    
+    private func closeAccessingBookmark() {
+        retrieveBookmark()?.stopAccessingSecurityScopedResource()
+    }
+    
+    private func existFolder(at url: URL) -> Bool {
+        FileManager.default.fileExists(atPath: url.path)
+    }
+    
+    // MARK: constants
+    private enum Key {
+        static let bookmark = "OpenPanel-writableFolder-bookmark"
+    }
+}


### PR DESCRIPTION
## Description
After Apple review, we need to let the user select the output folder. Currently, we are using the pre-set download location to ~/Downloads and Apple said the Downloads for should only be used files downloaded from the Internet.

- Launch to the user a dialogue to let to set up the output folder.
- Get the output and persist, and use the bookmarks entitlement to remember the user’s chosen location.
- Add in preferences view a new row to let the user change the last output choice.

![Screenshot 2019-10-14 at 15 54 14](https://user-images.githubusercontent.com/25568562/66757310-313e8300-ee9c-11e9-811e-486a30acdb89.png)
