### PR TITLE
Carbon image into the pasteboard

### DIFF
--- a/nef-plugin.xcodeproj/project.pbxproj
+++ b/nef-plugin.xcodeproj/project.pbxproj
@@ -53,6 +53,8 @@
 		8BF86CB72397CC990071B37C /* SourceEditorCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF86CB22397CC990071B37C /* SourceEditorCommand.swift */; };
 		8BF86CB82397CC990071B37C /* SourceEditorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF86CB32397CC990071B37C /* SourceEditorExtension.swift */; };
 		8BF9220623546D8D00C58AA0 /* OpenPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF9220523546D8D00C58AA0 /* OpenPanel.swift */; };
+		AF73C325248C196600168A64 /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF73C324248C196600168A64 /* Command.swift */; };
+		AF73C327248C1A4200168A64 /* URL+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF73C326248C1A4200168A64 /* URL+Extension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -142,6 +144,8 @@
 		8BF86CB22397CC990071B37C /* SourceEditorCommand.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SourceEditorCommand.swift; sourceTree = "<group>"; };
 		8BF86CB32397CC990071B37C /* SourceEditorExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SourceEditorExtension.swift; sourceTree = "<group>"; };
 		8BF9220523546D8D00C58AA0 /* OpenPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenPanel.swift; sourceTree = "<group>"; };
+		AF73C324248C196600168A64 /* Command.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Command.swift; sourceTree = "<group>"; };
+		AF73C326248C1A4200168A64 /* URL+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Extension.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -181,6 +185,7 @@
 				8B3B21A922F8329900E92BC9 /* Browser.swift */,
 				8B91B1922360A3690041F79B /* DispatchGroup.swift */,
 				8BF9220523546D8D00C58AA0 /* OpenPanel.swift */,
+				AF73C324248C196600168A64 /* Command.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -196,6 +201,7 @@
 				8BF68783239928BE006CC977 /* DispatchTimeInterval+Extensions.swift */,
 				8B75AF98238061FF00388B1C /* NSView+Layout.swift */,
 				8B7E0621235493F7003ED8E2 /* NSWindow+Extension.swift */,
+				AF73C326248C1A4200168A64 /* URL+Extension.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -498,6 +504,7 @@
 				8B7E0622235493F7003ED8E2 /* NSWindow+Extension.swift in Sources */,
 				8BF68FB322DE2154009E57A9 /* PreferencesViewModel.swift in Sources */,
 				8B4D1E1522D7A37E004432CF /* PickerOptionView.swift in Sources */,
+				AF73C327248C1A4200168A64 /* URL+Extension.swift in Sources */,
 				8B3B21AC22F8644000E92BC9 /* FixedToggle.swift in Sources */,
 				8B3B21A722F82AAE00E92BC9 /* AboutView.swift in Sources */,
 				8B7F5C85239807EF0040575D /* ProgressView.swift in Sources */,
@@ -511,6 +518,7 @@
 				8BF9220623546D8D00C58AA0 /* OpenPanel.swift in Sources */,
 				8BB2892E22CB6EFB006E4CCB /* AppDelegate.swift in Sources */,
 				8B7E0624235498CA003ED8E2 /* OutputFolderView.swift in Sources */,
+				AF73C325248C196600168A64 /* Command.swift in Sources */,
 				8B4D1E1722D88A5E004432CF /* OptionItem.swift in Sources */,
 				8BF68FB522DE2403009E57A9 /* CarbonStyle+Model.swift in Sources */,
 				8BAAB73D22D4DB2A00FD3636 /* Date+Extension.swift in Sources */,

--- a/nef-plugin.xcodeproj/project.pbxproj
+++ b/nef-plugin.xcodeproj/project.pbxproj
@@ -21,7 +21,7 @@
 		8B497A7D239A91EF00CEC130 /* nef in Frameworks */ = {isa = PBXBuildFile; productRef = 8B497A7C239A91EF00CEC130 /* nef */; settings = {ATTRIBUTES = (Required, ); }; };
 		8B4D1E1522D7A37E004432CF /* PickerOptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4D1E1422D7A37E004432CF /* PickerOptionView.swift */; };
 		8B4D1E1722D88A5E004432CF /* OptionItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4D1E1622D88A5E004432CF /* OptionItem.swift */; };
-		8B7583AC247278DA00C98A08 /* AppDelegate+Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7583AB247278DA00C98A08 /* AppDelegate+Notifications.swift */; };
+		8B7583AC247278DA00C98A08 /* AppDelegate+Clipboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7583AB247278DA00C98A08 /* AppDelegate+Clipboard.swift */; };
 		8B75AF99238061FF00388B1C /* NSView+Layout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B75AF98238061FF00388B1C /* NSView+Layout.swift */; };
 		8B7E0622235493F7003ED8E2 /* NSWindow+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7E0621235493F7003ED8E2 /* NSWindow+Extension.swift */; };
 		8B7E0624235498CA003ED8E2 /* OutputFolderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7E0623235498CA003ED8E2 /* OutputFolderView.swift */; };
@@ -56,6 +56,7 @@
 		AF73C325248C196600168A64 /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF73C324248C196600168A64 /* Command.swift */; };
 		AF73C327248C1A4200168A64 /* URL+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF73C326248C1A4200168A64 /* URL+Extension.swift */; };
 		AFD8024F24962732006E9297 /* NefNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFD8024E24962732006E9297 /* NefNotification.swift */; };
+		AFD8025124962BDE006E9297 /* AppDelegate+Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFD8025024962BDE006E9297 /* AppDelegate+Notifications.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -95,7 +96,7 @@
 		8B41588722D8E43A00588921 /* CarbonStyle+Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CarbonStyle+Color.swift"; sourceTree = "<group>"; };
 		8B4D1E1422D7A37E004432CF /* PickerOptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickerOptionView.swift; sourceTree = "<group>"; };
 		8B4D1E1622D88A5E004432CF /* OptionItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionItem.swift; sourceTree = "<group>"; };
-		8B7583AB247278DA00C98A08 /* AppDelegate+Notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+Notifications.swift"; sourceTree = "<group>"; };
+		8B7583AB247278DA00C98A08 /* AppDelegate+Clipboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+Clipboard.swift"; sourceTree = "<group>"; };
 		8B75AF98238061FF00388B1C /* NSView+Layout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSView+Layout.swift"; sourceTree = "<group>"; };
 		8B7E0621235493F7003ED8E2 /* NSWindow+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSWindow+Extension.swift"; sourceTree = "<group>"; };
 		8B7E0623235498CA003ED8E2 /* OutputFolderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutputFolderView.swift; sourceTree = "<group>"; };
@@ -148,6 +149,7 @@
 		AF73C324248C196600168A64 /* Command.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Command.swift; sourceTree = "<group>"; };
 		AF73C326248C1A4200168A64 /* URL+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Extension.swift"; sourceTree = "<group>"; };
 		AFD8024E24962732006E9297 /* NefNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NefNotification.swift; sourceTree = "<group>"; };
+		AFD8025024962BDE006E9297 /* AppDelegate+Notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+Notifications.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -196,7 +198,8 @@
 		8B41588622D8E42C00588921 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
-				8B7583AB247278DA00C98A08 /* AppDelegate+Notifications.swift */,
+				8B7583AB247278DA00C98A08 /* AppDelegate+Clipboard.swift */,
+				AFD8025024962BDE006E9297 /* AppDelegate+Notifications.swift */,
 				8B41588722D8E43A00588921 /* CarbonStyle+Color.swift */,
 				8BF68FB422DE2403009E57A9 /* CarbonStyle+Model.swift */,
 				8B230C82241C1DD400C31191 /* Data+IO.swift */,
@@ -513,6 +516,7 @@
 				8B7F5C85239807EF0040575D /* ProgressView.swift in Sources */,
 				8B230C83241C1DD500C31191 /* Data+IO.swift in Sources */,
 				8B7F5C832397DC820040575D /* PlaygroundBookProgressReport.swift in Sources */,
+				AFD8025124962BDE006E9297 /* AppDelegate+Notifications.swift in Sources */,
 				8B41588522D8DDE700588921 /* ImageButton.swift in Sources */,
 				8BF68FB122DE0ED4009E57A9 /* PreferencesModel.swift in Sources */,
 				8BF68FA322DDE268009E57A9 /* ActionViewModel.swift in Sources */,
@@ -531,7 +535,7 @@
 				8B3B21B022F86C5600E92BC9 /* SeparatorView.swift in Sources */,
 				8B1A0C2522D77AEC0049B48F /* PreferencesView.swift in Sources */,
 				8B7F5C822397DC820040575D /* PlaygroundBookView.swift in Sources */,
-				8B7583AC247278DA00C98A08 /* AppDelegate+Notifications.swift in Sources */,
+				8B7583AC247278DA00C98A08 /* AppDelegate+Clipboard.swift in Sources */,
 				8B75AF99238061FF00388B1C /* NSView+Layout.swift in Sources */,
 				8BF68F9F22DDD802009E57A9 /* PreferencesDataSource.swift in Sources */,
 				8B9F3CF322F036E3001EE2DF /* LoadingView.swift in Sources */,

--- a/nef-plugin.xcodeproj/project.pbxproj
+++ b/nef-plugin.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		8B497A7D239A91EF00CEC130 /* nef in Frameworks */ = {isa = PBXBuildFile; productRef = 8B497A7C239A91EF00CEC130 /* nef */; settings = {ATTRIBUTES = (Required, ); }; };
 		8B4D1E1522D7A37E004432CF /* PickerOptionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4D1E1422D7A37E004432CF /* PickerOptionView.swift */; };
 		8B4D1E1722D88A5E004432CF /* OptionItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B4D1E1622D88A5E004432CF /* OptionItem.swift */; };
+		8B7583AC247278DA00C98A08 /* AppDelegate+Notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7583AB247278DA00C98A08 /* AppDelegate+Notifications.swift */; };
 		8B75AF99238061FF00388B1C /* NSView+Layout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B75AF98238061FF00388B1C /* NSView+Layout.swift */; };
 		8B7E0622235493F7003ED8E2 /* NSWindow+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7E0621235493F7003ED8E2 /* NSWindow+Extension.swift */; };
 		8B7E0624235498CA003ED8E2 /* OutputFolderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B7E0623235498CA003ED8E2 /* OutputFolderView.swift */; };
@@ -91,6 +92,7 @@
 		8B41588722D8E43A00588921 /* CarbonStyle+Color.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CarbonStyle+Color.swift"; sourceTree = "<group>"; };
 		8B4D1E1422D7A37E004432CF /* PickerOptionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickerOptionView.swift; sourceTree = "<group>"; };
 		8B4D1E1622D88A5E004432CF /* OptionItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OptionItem.swift; sourceTree = "<group>"; };
+		8B7583AB247278DA00C98A08 /* AppDelegate+Notifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+Notifications.swift"; sourceTree = "<group>"; };
 		8B75AF98238061FF00388B1C /* NSView+Layout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "NSView+Layout.swift"; sourceTree = "<group>"; };
 		8B7E0621235493F7003ED8E2 /* NSWindow+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSWindow+Extension.swift"; sourceTree = "<group>"; };
 		8B7E0623235498CA003ED8E2 /* OutputFolderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutputFolderView.swift; sourceTree = "<group>"; };
@@ -186,6 +188,7 @@
 		8B41588622D8E42C00588921 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				8B7583AB247278DA00C98A08 /* AppDelegate+Notifications.swift */,
 				8B41588722D8E43A00588921 /* CarbonStyle+Color.swift */,
 				8BF68FB422DE2403009E57A9 /* CarbonStyle+Model.swift */,
 				8B230C82241C1DD400C31191 /* Data+IO.swift */,
@@ -264,15 +267,15 @@
 			children = (
 				8BB2892D22CB6EFB006E4CCB /* AppDelegate.swift */,
 				8BF68FA022DDD8BD009E57A9 /* Assembler.swift */,
-				8B3B21A522F8246E00E92BC9 /* About */,
-				8B41588922D8E45400588921 /* Preferences */,
-				8BBCA64F239558FC00BE058B /* PlaygroundBook */,
-				8B41588C22D8E48300588921 /* Views */,
-				8B3B21A822F8328B00E92BC9 /* Utils */,
-				8B41588622D8E42C00588921 /* Extensions */,
 				8BB2893122CB6EFD006E4CCB /* Assets.xcassets */,
+				8B3B21A522F8246E00E92BC9 /* About */,
+				8B41588622D8E42C00588921 /* Extensions */,
 				8BB2893622CB6EFD006E4CCB /* Main.storyboard */,
+				8BBCA64F239558FC00BE058B /* PlaygroundBook */,
+				8B41588922D8E45400588921 /* Preferences */,
 				8BB2896422CB6FF0006E4CCB /* Support Files */,
+				8B3B21A822F8328B00E92BC9 /* Utils */,
+				8B41588C22D8E48300588921 /* Views */,
 			);
 			path = nef;
 			sourceTree = "<group>";
@@ -517,6 +520,7 @@
 				8B3B21B022F86C5600E92BC9 /* SeparatorView.swift in Sources */,
 				8B1A0C2522D77AEC0049B48F /* PreferencesView.swift in Sources */,
 				8B7F5C822397DC820040575D /* PlaygroundBookView.swift in Sources */,
+				8B7583AC247278DA00C98A08 /* AppDelegate+Notifications.swift in Sources */,
 				8B75AF99238061FF00388B1C /* NSView+Layout.swift in Sources */,
 				8BF68F9F22DDD802009E57A9 /* PreferencesDataSource.swift in Sources */,
 				8B9F3CF322F036E3001EE2DF /* LoadingView.swift in Sources */,

--- a/nef-plugin.xcodeproj/project.pbxproj
+++ b/nef-plugin.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		8BF9220623546D8D00C58AA0 /* OpenPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BF9220523546D8D00C58AA0 /* OpenPanel.swift */; };
 		AF73C325248C196600168A64 /* Command.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF73C324248C196600168A64 /* Command.swift */; };
 		AF73C327248C1A4200168A64 /* URL+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF73C326248C1A4200168A64 /* URL+Extension.swift */; };
+		AFD8024F24962732006E9297 /* NefNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFD8024E24962732006E9297 /* NefNotification.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -146,6 +147,7 @@
 		8BF9220523546D8D00C58AA0 /* OpenPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenPanel.swift; sourceTree = "<group>"; };
 		AF73C324248C196600168A64 /* Command.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Command.swift; sourceTree = "<group>"; };
 		AF73C326248C1A4200168A64 /* URL+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Extension.swift"; sourceTree = "<group>"; };
+		AFD8024E24962732006E9297 /* NefNotification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NefNotification.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -186,6 +188,7 @@
 				8B91B1922360A3690041F79B /* DispatchGroup.swift */,
 				8BF9220523546D8D00C58AA0 /* OpenPanel.swift */,
 				AF73C324248C196600168A64 /* Command.swift */,
+				AFD8024E24962732006E9297 /* NefNotification.swift */,
 			);
 			path = Utils;
 			sourceTree = "<group>";
@@ -535,6 +538,7 @@
 				8B3B21AA22F8329900E92BC9 /* Browser.swift in Sources */,
 				8B3B21AE22F8691800E92BC9 /* InstallStepView.swift in Sources */,
 				8BF68784239928BE006CC977 /* DispatchTimeInterval+Extensions.swift in Sources */,
+				AFD8024F24962732006E9297 /* NefNotification.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/nef-plugin/AppScheme.swift
+++ b/nef-plugin/AppScheme.swift
@@ -6,6 +6,7 @@ struct AppScheme {
     enum Action {
         case preferences
         case carbon(selection: String)
+        case pasteboardCarbon(selection: String)
         case markdownPage(playground: String)
         case playgroundBook(package: String)
         
@@ -13,6 +14,7 @@ struct AppScheme {
             switch self {
             case .preferences: return URLQueryItem(name: "preferences", value: nil)
             case let .carbon(selection): return URLQueryItem(name: "carbon", value: selection)
+            case let .pasteboardCarbon(selection): return URLQueryItem(name: "pasteboardCarbon", value: selection)
             case let .markdownPage(playground): return URLQueryItem(name: "markdownPage", value: playground)
             case let .playgroundBook(package): return URLQueryItem(name: "playgroundBook", value: package)
             }

--- a/nef-plugin/AppScheme.swift
+++ b/nef-plugin/AppScheme.swift
@@ -6,7 +6,7 @@ struct AppScheme {
     enum Action {
         case preferences
         case carbon(selection: String)
-        case pasteboardCarbon(selection: String)
+        case clipboardCarbon(selection: String)
         case markdownPage(playground: String)
         case playgroundBook(package: String)
         
@@ -14,7 +14,7 @@ struct AppScheme {
             switch self {
             case .preferences: return URLQueryItem(name: "preferences", value: nil)
             case let .carbon(selection): return URLQueryItem(name: "carbon", value: selection)
-            case let .pasteboardCarbon(selection): return URLQueryItem(name: "pasteboardCarbon", value: selection)
+            case let .clipboardCarbon(selection): return URLQueryItem(name: "clipboardCarbon", value: selection)
             case let .markdownPage(playground): return URLQueryItem(name: "markdownPage", value: playground)
             case let .playgroundBook(package): return URLQueryItem(name: "playgroundBook", value: package)
             }

--- a/nef-plugin/SourceEditorCommand.swift
+++ b/nef-plugin/SourceEditorCommand.swift
@@ -18,8 +18,8 @@ class SourceEditorCommand: NSObject, XCSourceEditorCommand {
             preferences(completion: completion)
         case .exportSnippet:
             carbon(editor: editor, completion: completion)
-        case .exportSnippetToPasteboard:
-            pasteboardCarbon(editor: editor, completion: completion)
+        case .exportSnippetToClipboard:
+            clipboardCarbon(editor: editor, completion: completion)
         case .markdownPage:
             markdownPage(editor: editor, completion: completion)
         case .playgroundBook:
@@ -41,11 +41,11 @@ class SourceEditorCommand: NSObject, XCSourceEditorCommand {
         terminate(deadline: .now() + .seconds(5), completion)
     }
     
-    private func pasteboardCarbon(editor: Editor, completion: @escaping (Error?) -> Void) {
+    private func clipboardCarbon(editor: Editor, completion: @escaping (Error?) -> Void) {
         guard Reachability.isConnected else { completion(EditorError.internetConnection); return }
         guard let selection = editor.selection else { completion(EditorError.selection); return }
         
-        AppScheme(action: .pasteboardCarbon(selection: selection)).run()
+        AppScheme(action: .clipboardCarbon(selection: selection)).run()
         terminate(deadline: .now() + .seconds(5), completion)
     }
     

--- a/nef-plugin/SourceEditorCommand.swift
+++ b/nef-plugin/SourceEditorCommand.swift
@@ -18,6 +18,8 @@ class SourceEditorCommand: NSObject, XCSourceEditorCommand {
             preferences(completion: completion)
         case .exportSnippet:
             carbon(editor: editor, completion: completion)
+        case .exportSnippetToPasteboard:
+            pasteboardCarbon(editor: editor, completion: completion)
         case .markdownPage:
             markdownPage(editor: editor, completion: completion)
         case .playgroundBook:
@@ -36,6 +38,14 @@ class SourceEditorCommand: NSObject, XCSourceEditorCommand {
         guard let selection = editor.selection else { completion(EditorError.selection); return }
         
         AppScheme(action: .carbon(selection: selection)).run()
+        terminate(deadline: .now() + .seconds(5), completion)
+    }
+    
+    private func pasteboardCarbon(editor: Editor, completion: @escaping (Error?) -> Void) {
+        guard Reachability.isConnected else { completion(EditorError.internetConnection); return }
+        guard let selection = editor.selection else { completion(EditorError.selection); return }
+        
+        AppScheme(action: .pasteboardCarbon(selection: selection)).run()
         terminate(deadline: .now() + .seconds(5), completion)
     }
     

--- a/nef-plugin/SourceEditorExtension.swift
+++ b/nef-plugin/SourceEditorExtension.swift
@@ -9,6 +9,7 @@ class SourceEditorExtension: NSObject, XCSourceEditorExtension {
     enum Command: String {
         case preferences
         case exportSnippet
+        case exportSnippetToPasteboard
         case markdownPage
         case playgroundBook
     }

--- a/nef-plugin/SourceEditorExtension.swift
+++ b/nef-plugin/SourceEditorExtension.swift
@@ -9,7 +9,7 @@ class SourceEditorExtension: NSObject, XCSourceEditorExtension {
     enum Command: String {
         case preferences
         case exportSnippet
-        case exportSnippetToPasteboard
+        case exportSnippetToClipboard
         case markdownPage
         case playgroundBook
     }

--- a/nef-plugin/Support Files/Info-appstore.plist
+++ b/nef-plugin/Support Files/Info-appstore.plist
@@ -49,7 +49,15 @@
 					<key>XCSourceEditorCommandIdentifier</key>
 					<string>exportSnippet</string>
 					<key>XCSourceEditorCommandName</key>
-					<string>Code selection → Image</string>
+					<string>Code selection → Image (File)</string>
+				</dict>
+				<dict>
+					<key>XCSourceEditorCommandClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SourceEditorCommand</string>
+					<key>XCSourceEditorCommandIdentifier</key>
+					<string>exportSnippetToPasteboard</string>
+					<key>XCSourceEditorCommandName</key>
+					<string>Code selection → Image (Pasteboard)</string>
 				</dict>
 				<dict>
 					<key>XCSourceEditorCommandClassName</key>

--- a/nef-plugin/Support Files/Info-appstore.plist
+++ b/nef-plugin/Support Files/Info-appstore.plist
@@ -57,7 +57,7 @@
 					<key>XCSourceEditorCommandIdentifier</key>
 					<string>exportSnippetToPasteboard</string>
 					<key>XCSourceEditorCommandName</key>
-					<string>Code selection → Image (Pasteboard)</string>
+					<string>Code selection → Image (Clipboard)</string>
 				</dict>
 				<dict>
 					<key>XCSourceEditorCommandClassName</key>

--- a/nef-plugin/Support Files/Info-appstore.plist
+++ b/nef-plugin/Support Files/Info-appstore.plist
@@ -55,7 +55,7 @@
 					<key>XCSourceEditorCommandClassName</key>
 					<string>$(PRODUCT_MODULE_NAME).SourceEditorCommand</string>
 					<key>XCSourceEditorCommandIdentifier</key>
-					<string>exportSnippetToPasteboard</string>
+					<string>exportSnippetToClipboard</string>
 					<key>XCSourceEditorCommandName</key>
 					<string>Code selection → Image (Clipboard)</string>
 				</dict>

--- a/nef-plugin/Support Files/Info.plist
+++ b/nef-plugin/Support Files/Info.plist
@@ -49,7 +49,15 @@
 					<key>XCSourceEditorCommandIdentifier</key>
 					<string>exportSnippet</string>
 					<key>XCSourceEditorCommandName</key>
-					<string>Code selection → Image</string>
+					<string>Code selection → Image (File)</string>
+				</dict>
+				<dict>
+					<key>XCSourceEditorCommandClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SourceEditorCommand</string>
+					<key>XCSourceEditorCommandIdentifier</key>
+					<string>exportSnippetToPasteboard</string>
+					<key>XCSourceEditorCommandName</key>
+					<string>Code selection → Image (Pasteboard)</string>
 				</dict>
 				<dict>
 					<key>XCSourceEditorCommandClassName</key>

--- a/nef-plugin/Support Files/Info.plist
+++ b/nef-plugin/Support Files/Info.plist
@@ -57,7 +57,7 @@
 					<key>XCSourceEditorCommandIdentifier</key>
 					<string>exportSnippetToPasteboard</string>
 					<key>XCSourceEditorCommandName</key>
-					<string>Code selection → Image (Pasteboard)</string>
+					<string>Code selection → Image (Clipboard)</string>
 				</dict>
 				<dict>
 					<key>XCSourceEditorCommandClassName</key>

--- a/nef-plugin/Support Files/Info.plist
+++ b/nef-plugin/Support Files/Info.plist
@@ -55,7 +55,7 @@
 					<key>XCSourceEditorCommandClassName</key>
 					<string>$(PRODUCT_MODULE_NAME).SourceEditorCommand</string>
 					<key>XCSourceEditorCommandIdentifier</key>
-					<string>exportSnippetToPasteboard</string>
+					<string>exportSnippetToClipboard</string>
 					<key>XCSourceEditorCommandName</key>
 					<string>Code selection → Image (Clipboard)</string>
 				</dict>

--- a/nef/AppDelegate.swift
+++ b/nef/AppDelegate.swift
@@ -6,16 +6,16 @@ import BowEffects
 
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate {
-    var window: NSWindow!
-    private let assembler = Assembler()
     var command: Command?
-    @IBOutlet weak var aboutMenuItem: NSMenuItem!
+    private let assembler = Assembler()
+    private var window: NSWindow!
+    @IBOutlet private weak var aboutMenuItem: NSMenuItem!
     
     func applicationDidFinishLaunching(_ aNotification: Notification) {
         registerNotifications()
         
         if let command = command {
-            schemaURLDidFinishLaunching(command: command)
+            commandDidFinishLaunching(command: command)
         } else {
             defaultDidFinishLaunching(aNotification)
         }
@@ -40,10 +40,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     
     // MARK: life cycle
     private func defaultDidFinishLaunching(_ aNotification: Notification) {
+        guard !isLocalNotification(aNotification) else { return }
         aboutDidFinishLaunching()
     }
     
-    private func schemaURLDidFinishLaunching(command: Command) {
+    private func commandDidFinishLaunching(command: Command) {
         switch command {
         case .preferences:
             preferencesDidFinishLaunching()

--- a/nef/AppDelegate.swift
+++ b/nef/AppDelegate.swift
@@ -188,7 +188,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }^.mapError { _ in .swiftPlayground }
     }
     
-    private func showFile(_ file: URL) {
+    func showFile(_ file: URL) {
         NSWorkspace.shared.activateFileViewerSelecting([file])
     }
     

--- a/nef/AppDelegate.swift
+++ b/nef/AppDelegate.swift
@@ -108,7 +108,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         guard !code.isEmpty else { terminate(); return }
         emptyDidFinishLaunching()
         
-        let config = ClipboardConfig(clipboard: .general, notificationCenter: .current())
+        let config = Clipboard.Config(clipboard: .general, notificationCenter: .current())
         
         assembler.resolveCarbon(code: code).env()^.mapError { _ in .carbon }
             .flatMap(pasteboardCarbonIO)^

--- a/nef/AppDelegate.swift
+++ b/nef/AppDelegate.swift
@@ -50,8 +50,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             preferencesDidFinishLaunching()
         case .carbon(let code):
             carbonDidFinishLaunching(code: code)
-        case .pasteboardCarbon(let code):
-            pasteboardCarbonDidFinishLaunching(code: code)
+        case .clipboardCarbon(let code):
+            clipboardCarbonDidFinishLaunching(code: code)
         case .markdownPage(let playground):
             markdownPageDidFinishLaunching(playground: playground)
         case .playgroundBook(let package):
@@ -104,14 +104,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         }
     }
     
-    private func pasteboardCarbonDidFinishLaunching(code: String) {
+    private func clipboardCarbonDidFinishLaunching(code: String) {
         guard !code.isEmpty else { terminate(); return }
         emptyDidFinishLaunching()
         
         let config = Clipboard.Config(clipboard: .general, notificationCenter: .current())
         
         assembler.resolveCarbon(code: code).env()^.mapError { _ in .carbon }
-            .flatMap(pasteboardCarbonIO)^
+            .flatMap(clipboardCarbonIO)^
             .provide(config)
             .unsafeRunAsync(on: .global(qos: .userInitiated)) { output in
                 _ = output.map { _ in
@@ -231,8 +231,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             return .preferences
         case let ("carbon", value):
             return .carbon(code: value)
-        case let ("pasteboardCarbon", value):
-            return .pasteboardCarbon(code: value)
+        case let ("clipboardCarbon", value):
+            return .clipboardCarbon(code: value)
         case let ("markdownPage", value):
             return .markdownPage(playground: value)
         case let ("playgroundBook", value):

--- a/nef/AppDelegate.swift
+++ b/nef/AppDelegate.swift
@@ -20,6 +20,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             preferencesDidFinishLaunching()
         case .carbon(let code):
             carbonDidFinishLaunching(code: code)
+        case .pasteboardCarbon(code: let code):
+            print(code)
         case .markdownPage(let playground):
             markdownPageDidFinishLaunching(playground: playground)
         case .playgroundBook(let package):

--- a/nef/AppDelegate.swift
+++ b/nef/AppDelegate.swift
@@ -99,6 +99,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         
         pasteboardCarbonIO(code: code).unsafeRunAsync(on: .global(qos: .userInitiated)) { output in
             _ = output.map(self.writeToPasteboard)
+            self.showPasterboardFinishedNotification()
             self.terminate()
         }
     }
@@ -208,6 +209,19 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         pb.writeObjects([image])
     }
     
+    private func showPasterboardFinishedNotification() {
+        let notification = NSUserNotification()
+        notification.identifier = "unique-id"
+        notification.title = "Snippet created"
+        notification.subtitle = "Your image was copied to the pasteboard!"
+        notification.deliveryDate = Date(timeIntervalSinceNow: 1)
+        NSUserNotificationCenter.default.delegate = self
+        DispatchQueue.main.async {
+            NSUserNotificationCenter.default.scheduleNotification(notification)
+        }
+        
+    }
+    
     private func terminate() {
         DispatchQueue.main.async {
             NSApplication.shared.terminate(nil)
@@ -281,5 +295,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         case carbon
         case markdown
         case swiftPlayground
+    }
+}
+
+extension AppDelegate: NSUserNotificationCenterDelegate {
+    func userNotificationCenter(_ center: NSUserNotificationCenter, shouldPresent notification: NSUserNotification) -> Bool {
+        true
     }
 }

--- a/nef/AppDelegate.swift
+++ b/nef/AppDelegate.swift
@@ -154,11 +154,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private func notificationDidFinishLaunching(userInfo: [String: Any], action: String) {
         emptyDidFinishLaunching()
         
-        let io = processNotification(userInfo, action: action)
-        io.unsafeRunAsync(on: .global(qos: .userInitiated)) { output in
-            _ = output.map { either in either.map(self.showFile) }
-            self.terminate()
-        }
+        processNotification(userInfo, action: action).env()
+            .flatMap(showClipboardFile)^
+            .provide(NSWorkspace.shared)
+            .unsafeRunAsync(on: .global(qos: .userInitiated)) { _ in self.terminate() }
     }
     
     // MARK: Helper methods

--- a/nef/AppDelegate.swift
+++ b/nef/AppDelegate.swift
@@ -111,6 +111,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         pasteboardCarbonIO(code: code).unsafeRunAsync(on: .global(qos: .userInitiated)) { output in
             _ = output.map { outputImage in
                 self.writeToPasteboard(outputImage.image)
+                self.removeOldNotifications()
                 self.showNotification(title: "nef", body: "Image copied to pasteboard!", imageData: outputImage.data, actions: [.cancel, .saveImage])
             }
             

--- a/nef/AppDelegate.swift
+++ b/nef/AppDelegate.swift
@@ -110,7 +110,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         
         let config = ClipboardConfig(clipboard: .general, notificationCenter: .current())
         
-        assembler.resolveCarbon(code: code).env()^
+        assembler.resolveCarbon(code: code).env()^.mapError { _ in .carbon }
             .flatMap(pasteboardCarbonIO)^
             .provide(config)
             .unsafeRunAsync(on: .global(qos: .userInitiated)) { output in

--- a/nef/Extensions/AppDelegate+Clipboard.swift
+++ b/nef/Extensions/AppDelegate+Clipboard.swift
@@ -1,0 +1,49 @@
+//  Copyright © 2020 The nef Authors.
+
+import AppKit
+import Bow
+import BowEffects
+
+extension AppDelegate {
+    func clipboardCarbonIO(data: Data) -> EnvIO<Clipboard.Config, Clipboard.Error, NSImage> {
+        func makeImage(_ data: Data) -> IO<Clipboard.Error, NSImage> {
+            data.makeImage().mapError { _ in .invalidData }
+        }
+        
+        let image = EnvIO<Clipboard.Config, Clipboard.Error, NSImage>.var()
+        
+        return binding(
+            image <- makeImage(data).env(),
+            |<-self.writeToClipboard(image.get),
+            |<-self.removeOldNotifications(),
+            |<-self.showNotification(title: "nef",
+                                     body: "Image copied to clipboard!",
+                                     imageData: data,
+                                     actions: [.cancel, .saveImage]),
+        yield:image.get)^
+    }
+    
+    func showClipboardFile(response: NefNotification.Response) -> EnvIO<NotificationConfig, NefNotification.Error, Void> {
+        guard case let .saveImage(url) = response else { return EnvIO.pure(())^ }
+        
+        return EnvIO.invoke { config in
+            config.workspace.activateFileViewerSelecting([url])
+        }^
+    }
+}
+
+private extension AppDelegate {
+    func writeToClipboard(_ image: NSImage) -> EnvIO<Clipboard.Config, Clipboard.Error, Void> {
+        EnvIO.invoke { config in
+            config.clipboard.clearContents()
+            if !config.clipboard.writeObjects([image]) {
+                throw Clipboard.Error.writeToClipboard
+            }
+        }^
+    }
+}
+
+struct NotificationConfig {
+    let workspace: NSWorkspace
+    let openPanel: OpenPanel
+}

--- a/nef/Extensions/AppDelegate+Notifications.swift
+++ b/nef/Extensions/AppDelegate+Notifications.swift
@@ -18,7 +18,11 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         NefNotification.center.requestAuthorization(options: [.alert, .sound]) { granted, _  in }
     }
     
-    func showNotification(title: String, body: String, imageData: Data? = nil, actions: [NefNotificationAction] = [], id: String = UUID().uuidString) {
+    func removeOldNotifications() {
+        NefNotification.center.removeAllDeliveredNotifications()
+    }
+    
+    func showNotification(title: String, body: String, imageData: Data? = nil, actions: [NefNotification.Action] = [], id: String = UUID().uuidString) {
         let content = UNMutableNotificationContent()
         content.title = title
         content.body = body

--- a/nef/Extensions/AppDelegate+Notifications.swift
+++ b/nef/Extensions/AppDelegate+Notifications.swift
@@ -29,7 +29,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         content.categoryIdentifier = id
         
         if let data = imageData {
-            content.userInfo = [NefNotification.Key.imageDataUserInfoKey: data]
+            content.userInfo = [NefNotification.UserInfoKey.imageData: data]
         }
         
         let category = UNNotificationCategory(identifier: id,
@@ -58,7 +58,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     }
     
     func processNotification(_ userInfo: [String: Any], action: String) -> IO<AppDelegate.Error, Either<Void, URL>> {
-        guard let image = userInfo[NefNotification.Key.imageDataUserInfoKey] as? Data else { return IO.raiseError(.notification)^ }
+        guard let image = userInfo[NefNotification.UserInfoKey.imageData] as? Data else { return IO.raiseError(.notification)^ }
         
         switch action {
         case NefNotification.Action.saveImage.identifier:
@@ -97,8 +97,8 @@ extension NefNotification {
 }
 
 extension NefNotification {
-    enum Key {
-        static let imageDataUserInfoKey = "imageDataUserInfoKey"
+    enum UserInfoKey {
+        static let imageData = "imageDataUserInfoKey"
     }
 }
 

--- a/nef/Extensions/AppDelegate+Notifications.swift
+++ b/nef/Extensions/AppDelegate+Notifications.swift
@@ -18,31 +18,33 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         NefNotification.center.requestAuthorization(options: [.alert, .sound]) { granted, _  in }
     }
     
-    func removeOldNotifications() {
-        NefNotification.center.removeAllDeliveredNotifications()
+    func removeOldNotifications() -> IO<AppDelegate.Error, Void> {
+        IO.invoke { NefNotification.center.removeAllDeliveredNotifications() }^
     }
     
-    func showNotification(title: String, body: String, imageData: Data? = nil, actions: [NefNotification.Action] = [], id: String = UUID().uuidString) {
-        let content = UNMutableNotificationContent()
-        content.title = title
-        content.body = body
-        content.categoryIdentifier = id
-        
-        if let data = imageData {
-            content.userInfo = [NefNotification.UserInfoKey.imageData: data]
-        }
-        
-        let category = UNNotificationCategory(identifier: id,
-                                              actions: actions.map(\.unNotificationAction),
-                                              intentIdentifiers: [],
-                                              hiddenPreviewsBodyPlaceholder: "",
-                                              options: .customDismissAction)
-        
-        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 0.5, repeats: false)
-        let request = UNNotificationRequest(identifier: id, content: content, trigger: trigger)
-        
-        NefNotification.center.setNotificationCategories([category])
-        NefNotification.center.add(request)
+    func showNotification(title: String, body: String, imageData: Data? = nil, actions: [NefNotification.Action] = [], id: String = UUID().uuidString) -> IO<AppDelegate.Error, Void> {
+        IO.invoke {
+            let content = UNMutableNotificationContent()
+            content.title = title
+            content.body = body
+            content.categoryIdentifier = id
+            
+            if let data = imageData {
+                content.userInfo = [NefNotification.UserInfoKey.imageData: data]
+            }
+            
+            let category = UNNotificationCategory(identifier: id,
+                                                  actions: actions.map(\.unNotificationAction),
+                                                  intentIdentifiers: [],
+                                                  hiddenPreviewsBodyPlaceholder: "",
+                                                  options: .customDismissAction)
+            
+            let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 0.5, repeats: false)
+            let request = UNNotificationRequest(identifier: id, content: content, trigger: trigger)
+            
+            NefNotification.center.setNotificationCategories([category])
+            NefNotification.center.add(request)
+        }^
     }
     
     // MARK: delegate <UNUserNotificationCenterDelegate>

--- a/nef/Extensions/AppDelegate+Notifications.swift
+++ b/nef/Extensions/AppDelegate+Notifications.swift
@@ -1,0 +1,58 @@
+//  Copyright © 2020 The nef Authors.
+
+import Foundation
+import UserNotifications
+
+extension AppDelegate: UNUserNotificationCenterDelegate {
+    func registerNotifications() {
+        UNUserNotificationCenter.current()
+            .requestAuthorization(options: [.alert, .sound]) { granted, _  in }
+    }
+    
+    func showNotification(title: String, body: String, actions: [NefNotificationAction] = []) {
+        let notificationCenter = UNUserNotificationCenter.current()
+        let notificationId = UUID().uuidString
+        let categoryId = "CATEGORY_IDENTIFIER_\(notificationId)"
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = body
+        content.categoryIdentifier = categoryId
+        
+        let category = UNNotificationCategory(identifier: categoryId,
+                                              actions: actions.map(\.unNotificationAction),
+                                              intentIdentifiers: [],
+                                              hiddenPreviewsBodyPlaceholder: "",
+                                              options: .customDismissAction)
+        
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
+        let request = UNNotificationRequest(identifier: notificationId, content: content, trigger: trigger)
+        
+        notificationCenter.delegate = self
+        notificationCenter.setNotificationCategories([category])
+        notificationCenter.add(request) { _ in }
+    }
+    
+    // MARK: delegate <UNUserNotificationCenterDelegate>
+    func userNotificationCenter(_ center: UNUserNotificationCenter, didReceive response: UNNotificationResponse, withCompletionHandler completionHandler: @escaping () -> Void) {
+        // TODO
+    }
+}
+
+enum NefNotificationAction: Equatable {
+    case store(title: String)
+    
+    var title: String {
+        switch self {
+        case .store(let title): return title
+        }
+    }
+}
+
+// MARK: - Helpers
+private extension NefNotificationAction {
+    var unNotificationAction: UNNotificationAction {
+        .init(identifier: "\(self)",
+              title: self.title,
+              options: .foreground)
+    }
+}

--- a/nef/Extensions/AppDelegate+Notifications.swift
+++ b/nef/Extensions/AppDelegate+Notifications.swift
@@ -14,33 +14,30 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
     }
     
     func registerNotifications() {
-        let notificationCenter = UNUserNotificationCenter.current()
         notificationCenter.delegate = self
         notificationCenter.requestAuthorization(options: [.alert, .sound]) { granted, _  in }
     }
     
-    func showNotification(title: String, body: String, imageData: Data? = nil, actions: [NefNotificationAction] = []) {
-        let notificationCenter = UNUserNotificationCenter.current()
-        let notificationId = UUID().uuidString
-        let categoryId = "CATEGORY_IDENTIFIER_\(notificationId)"
+    func showNotification(title: String, body: String, imageData: Data? = nil, actions: [NefNotificationAction] = [], id: String = UUID().uuidString) {
         let content = UNMutableNotificationContent()
         content.title = title
         content.body = body
-        content.categoryIdentifier = categoryId
+        content.categoryIdentifier = id
         
         if let data = imageData {
             content.userInfo = [Self.imageDataUserInfoKey: data]
         }
         
-        let category = UNNotificationCategory(identifier: categoryId,
+        let category = UNNotificationCategory(identifier: id,
                                               actions: actions.map(\.unNotificationAction),
                                               intentIdentifiers: [],
                                               hiddenPreviewsBodyPlaceholder: "",
                                               options: .customDismissAction)
         
-        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 1, repeats: false)
-        let request = UNNotificationRequest(identifier: notificationId, content: content, trigger: trigger)
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: 0.5, repeats: false)
+        let request = UNNotificationRequest(identifier: id, content: content, trigger: trigger)
         
+        notificationCenter.removeAllDeliveredNotifications()
         notificationCenter.setNotificationCategories([category])
         notificationCenter.add(request)
     }
@@ -73,6 +70,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
 
 private extension AppDelegate {
     static let imageDataUserInfoKey = "imageDataUserInfoKey"
+    var notificationCenter: UNUserNotificationCenter { .current() }
 }
 
 enum NefNotificationAction: Equatable {

--- a/nef/Extensions/AppDelegate+Notifications.swift
+++ b/nef/Extensions/AppDelegate+Notifications.swift
@@ -6,7 +6,7 @@ import Bow
 import BowEffects
 
 extension AppDelegate {
-    func pasteboardCarbonIO(data: Data) -> EnvIO<Clipboard.Config, Clipboard.Error, NSImage> {
+    func clipboardCarbonIO(data: Data) -> EnvIO<Clipboard.Config, Clipboard.Error, NSImage> {
         func makeImage(_ data: Data) -> IO<Clipboard.Error, NSImage> {
             data.makeImage().mapError { _ in .invalidData }
         }
@@ -15,16 +15,16 @@ extension AppDelegate {
         
         return binding(
             image <- makeImage(data).env(),
-            |<-self.writeToPasteboard(image.get),
+            |<-self.writeToClipboard(image.get),
             |<-self.removeOldNotifications(),
             |<-self.showNotification(title: "nef",
-                                     body: "Image copied to pasteboard!",
+                                     body: "Image copied to clipboard!",
                                      imageData: data,
                                      actions: [.cancel, .saveImage]),
         yield:image.get)^
     }
     
-    private func writeToPasteboard(_ image: NSImage) -> EnvIO<Clipboard.Config, Clipboard.Error, Void> {
+    private func writeToClipboard(_ image: NSImage) -> EnvIO<Clipboard.Config, Clipboard.Error, Void> {
         EnvIO.invoke { config in
             config.clipboard.clearContents()
             if !config.clipboard.writeObjects([image]) {
@@ -96,7 +96,7 @@ extension AppDelegate: UNUserNotificationCenterDelegate {
         switch action {
         case NefNotification.Action.saveImage.identifier:
             return image
-                .persist    (command: .pasteboardCarbon())
+                .persist    (command: .clipboardCarbon())
                 .mapError { _ in .persistImage }
                 .contramap(\.openPanel)
                 .map { .saveImage($0) }^

--- a/nef/Extensions/Data+IO.swift
+++ b/nef/Extensions/Data+IO.swift
@@ -3,11 +3,25 @@
 import Foundation
 import Bow
 import BowEffects
+import AppKit
+
+enum ImageError: Error {
+    case invalidData
+}
 
 extension Data {
     func writeIO(to url: URL) -> IO<Error, Void> {
         IO.invoke {
             try self.write(to: url)
+        }
+    }
+    
+    func makeImage() -> IO<ImageError, NSImage> {
+        IO.invoke {
+            guard let image = NSImage(data: self) else {
+                throw ImageError.invalidData
+            }
+            return image
         }
     }
 }

--- a/nef/Extensions/Data+IO.swift
+++ b/nef/Extensions/Data+IO.swift
@@ -24,4 +24,14 @@ extension Data {
             return image
         }
     }
+    
+    func persistImage(command: Command, assembler: Assembler = Assembler()) -> IO<AppDelegate.Error, URL> {
+        assembler.resolveOpenPanel().writableFolder(create: true).use { folder in
+            let output = IO<OpenPanelError, URL>.var()
+            return binding(
+                output <- folder.outputURL(command: command),
+                       |<-self.writeIO(to: output.get).mapError { _ in .unknown },
+            yield: output.get)
+        }^.mapError { _ in .carbon }^
+    }
 }

--- a/nef/Extensions/URL+Extension.swift
+++ b/nef/Extensions/URL+Extension.swift
@@ -13,7 +13,7 @@ extension URL {
     func appendingCommandExtensionComponent(command: Command) -> URL {
         let ext: String
         switch command {
-        case .carbon, .pasteboardCarbon: ext = "jpg"
+        case .carbon, .clipboardCarbon: ext = "jpg"
         case .markdownPage: ext = "md"
         default: ext = ""
         }

--- a/nef/Extensions/URL+Extension.swift
+++ b/nef/Extensions/URL+Extension.swift
@@ -1,0 +1,11 @@
+//  Copyright © 2020 The nef Authors.
+
+import Foundation
+import BowEffects
+
+extension URL {
+    func outputURL(command: Command) -> IO<OpenPanelError, URL> {
+        let filename = "nef-\(command) \(Date.now.human)"
+        return IO.pure(appendingPathComponent(filename))^
+    }
+}

--- a/nef/Extensions/URL+Extension.swift
+++ b/nef/Extensions/URL+Extension.swift
@@ -6,6 +6,18 @@ import BowEffects
 extension URL {
     func outputURL(command: Command) -> IO<OpenPanelError, URL> {
         let filename = "nef-\(command) \(Date.now.human)"
-        return IO.pure(appendingPathComponent(filename))^
+        let url = appendingPathComponent(filename).appendingCommandExtensionComponent(command: command)
+        return IO.pure(url)^
+    }
+    
+    func appendingCommandExtensionComponent(command: Command) -> URL {
+        let ext: String
+        switch command {
+        case .carbon, .pasteboardCarbon: ext = "jpg"
+        case .markdownPage: ext = "md"
+        default: ext = ""
+        }
+        
+        return appendingPathExtension(ext)
     }
 }

--- a/nef/Support Files/Info.plist
+++ b/nef/Support Files/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSUserNotificationAlertStyle</key>
+	<string>banner</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleExecutable</key>

--- a/nef/Utils/Command.swift
+++ b/nef/Utils/Command.swift
@@ -1,0 +1,21 @@
+//  Copyright © 2020 The nef Authors.
+
+enum Command: CustomStringConvertible {
+    case about
+    case preferences
+    case carbon(code: String)
+    case pasteboardCarbon(code: String)
+    case markdownPage(playground: String)
+    case playgroundBook(package: String)
+    
+    var description: String {
+        switch self {
+        case .about: return "about"
+        case .preferences: return "preferences"
+        case .carbon: return "carbon"
+        case .pasteboardCarbon: return "pasteboardCarbon"
+        case .markdownPage: return "markdown"
+        case .playgroundBook: return "playground-book"
+        }
+    }
+}

--- a/nef/Utils/Command.swift
+++ b/nef/Utils/Command.swift
@@ -4,7 +4,7 @@ enum Command: CustomStringConvertible {
     case about
     case preferences
     case carbon(code: String)
-    case pasteboardCarbon(code: String = "")
+    case clipboardCarbon(code: String = "")
     case markdownPage(playground: String)
     case playgroundBook(package: String)
     case notification(userInfo: [String: Any], action: String)
@@ -14,7 +14,7 @@ enum Command: CustomStringConvertible {
         case .about: return "about"
         case .preferences: return "preferences"
         case .carbon: return "carbon"
-        case .pasteboardCarbon: return "pasteboardCarbon"
+        case .clipboardCarbon: return "clipboardCarbon"
         case .markdownPage: return "markdown"
         case .playgroundBook: return "playground-book"
         case .notification: return "notification"

--- a/nef/Utils/Command.swift
+++ b/nef/Utils/Command.swift
@@ -4,9 +4,10 @@ enum Command: CustomStringConvertible {
     case about
     case preferences
     case carbon(code: String)
-    case pasteboardCarbon(code: String)
+    case pasteboardCarbon(code: String = "")
     case markdownPage(playground: String)
     case playgroundBook(package: String)
+    case notification(userInfo: [String: Any], action: String)
     
     var description: String {
         switch self {
@@ -16,6 +17,7 @@ enum Command: CustomStringConvertible {
         case .pasteboardCarbon: return "pasteboardCarbon"
         case .markdownPage: return "markdown"
         case .playgroundBook: return "playground-book"
+        case .notification: return "notification"
         }
     }
 }

--- a/nef/Utils/Command.swift
+++ b/nef/Utils/Command.swift
@@ -4,7 +4,7 @@ enum Command: CustomStringConvertible {
     case about
     case preferences
     case carbon(code: String)
-    case clipboardCarbon(code: String = "")
+    case clipboardCarbon(code: String)
     case markdownPage(playground: String)
     case playgroundBook(package: String)
     case notification(userInfo: [String: Any], action: String)

--- a/nef/Utils/NefNotification.swift
+++ b/nef/Utils/NefNotification.swift
@@ -1,0 +1,39 @@
+//  Copyright © 2020 The nef Authors.
+
+import UserNotifications
+
+enum NefNotification {
+    enum Action: Equatable {
+        case saveImage
+        case cancel
+        
+        var title: String {
+            switch self {
+            case .saveImage: return "Save to disk"
+            case .cancel: return "Cancel"
+            }
+        }
+        
+        var identifier: String {
+            switch self {
+            case .saveImage: return String(describing: self)
+            case .cancel: return UNNotificationDismissActionIdentifier
+            }
+        }
+    }
+    
+    enum Response {
+        case saveImage(URL)
+        case dismiss
+    }
+    
+    enum UserInfoKey {
+        static let imageData = "imageDataUserInfoKey"
+    }
+    
+    enum Error: Swift.Error {
+        case noImageData
+        case unsupportedAction
+        case persistImage
+    }
+}

--- a/nef/Utils/OpenPanel.swift
+++ b/nef/Utils/OpenPanel.swift
@@ -11,7 +11,6 @@ enum OpenPanelError: Error {
     case unknown
 }
 
-
 class OpenPanel {
     private let dialog: NSOpenPanel
     @Bookmark(key: Key.bookmark) private var bookmark: URL?


### PR DESCRIPTION
The aim of this PR is to provide an option to create a carbon image from a code snippet and copy it into the pasteboard, so it can be pasted anywhere by the user.

When the snippet has been created and copied, the user will see a local notification with a "Save to disk" action that will save it to the directory if the user presses it.